### PR TITLE
Relying on global dataLayer vars

### DIFF
--- a/ga-tracking.js
+++ b/ga-tracking.js
@@ -1,39 +1,46 @@
-var gaTracker = (function(dLayer) {
+var gaTracker = (function() {
 
     // Push the object to the dataLayer
     // Parameters:
     // eventName, category, action, label, Type String
     // value Type Number (int)
     var pushEventToDataLayer = function(eventName, category, action, label, value) {
-        dLayer.push({
-            'event': eventName, // on GTM this would be the event that triggers the tag.
-            'category': category,
-            'action': action,
-            'label': label,
-            'value': value
-        });
+
+        if (typeof window.dataLayer === 'object') {
+            window.dataLayer.push({
+                'event': eventName, // on GTM this would be the event that triggers the tag.
+                'category': category,
+                'action': action,
+                'label': label,
+                'value': value
+            });
+        } else {
+            console.log('dataLayer not defined');
+        }
+
     };
 
     var isUniversalAnalytics = function(ga) {
-        return typeof ga !== 'undefined' && typeof ga.getAll === 'function' ? true : false;
+        return typeof ga.getAll === 'function' ? true : false;
     };
 
     var isClassicAnalytics = function(_gat) {
-        return typeof _gat !== 'undefined' && typeof _gat._getTrackers === 'function' ? true : false;
+        return typeof _gat._getTrackers === 'function' ? true : false;
     };
 
     // decorate target URL for cross domain tracker.
     var decorateLink = function(url) {
-        var trackers, linker;
+        var trackers;
+        var linker;
 
-        if (isUniversalAnalytics(ga)) {
-            trackers = ga.getAll();
+        if (typeof window.ga !== 'undefined' && isUniversalAnalytics(window.ga)) {
+            trackers = window.ga.getAll();
             if (trackers.length) {
                 linker = new window.gaplugins.Linker(trackers[0]);
                 url = linker.decorate(url);
             }
-        } else if (isClassicAnalytics(_gat)) {
-            trackers = _gat._getTrackers();
+        } else if (typeof window._gat !== 'undefined' && isClassicAnalytics(window._gat)) {
+            trackers = window._gat._getTrackers();
             if (trackers.length) {
                 url = trackers[0]._getLinkerUrl(url);
             }
@@ -43,8 +50,8 @@ var gaTracker = (function(dLayer) {
     };
 
     return {
-        event: pushEventToDataLayer,
+        pushEvent: pushEventToDataLayer,
         decorateLink: decorateLink
     };
 
-})(dataLayer);
+})();


### PR DESCRIPTION
... so GaTracker works better when used as a module. Before the self invoking function would try to access the dataLayer variable before it was defined.
